### PR TITLE
Added functionality for fetching pipelines and deals for pipelines

### DIFF
--- a/pipedrive/client.py
+++ b/pipedrive/client.py
@@ -172,6 +172,19 @@ class Client:
             params.update(kwargs)
             return self._post(endpoint, json=params)
 
+    # Pipeline section, see the api documentation: https://developers.pipedrive.com/docs/api/v1/#!/Pipelines
+    def get_pipelines(self, pipeline_id=None, **kwargs):
+        if pipeline_id is not None:
+            url = "pipelines/{0}".format(pipeline_id)
+        else:
+            url = "pipelines"
+        return self._get(url, **kwargs)
+
+    def get_pipeline_deals(self, pipeline_id, **kwargs):
+        if pipeline_id is not None:
+            url = "pipelines/{0}/deals".format(pipeline_id)
+        return self._get(url, **kwargs)
+
     # Deals section, see the api documentation: https://developers.pipedrive.com/docs/api/v1/#!/Deals
     def get_deals(self, deal_id=None, **kwargs):
         if deal_id is not None:


### PR DESCRIPTION
Thanks for the easy to work with library!

This commit adds get_pipelines and get_pipeline_deals
My motivation for this is so I can close rotten deals.

```
deals = client.get_pipeline_deals(2)
for deal in deals["data"]:
    if (deal["rotten_time"] and deal["status"] == "open"):
        print(deal["rotten_time"],deal["status"])

```