### PR TITLE
Adds support to API token

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ pip install pipedrive-python-lib
 
 ## Usage
 
+### Using this library with OAuth 2.0
+
 #### Client instantiation
 ```
 from pipedrive.client import Client
 
 client = Client('CLIENT_ID', 'CLIENT_SECRET')
 ```
-
-### OAuth 2.0
 
 #### Get authorization url
 ```
@@ -36,6 +36,20 @@ client.set_access_token('ACCESS_TOKEN')
 #### Refresh token
 ```
 token = client.refresh_token('REFRESH_TOKEN')
+```
+
+### Using this library with API Token
+
+#### Client instantiation
+```
+from pipedrive.client import Client
+
+client = Client(domain='https://companydomain.pipedrive.com/')
+```
+
+#### Set API token in the library
+```
+client.set_api_token('API_TOKEN')
 ```
 
 ### Activities 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
 
 
 setup(name='pipedrive-python-lib',
-      version='1.0.0',
+      version='1.1.0',
       description='API wrapper for Pipedrive written in Python',
       long_description=read('README.md'),
       long_description_content_type="text/markdown",


### PR DESCRIPTION
In the recent library rework, I dropped the [manual integration](https://pipedrive.readme.io/docs/core-api-concepts-authentication) (API Token) because I confused it with API Keys which is now deprecated by Pipedrive.

The [deprecation warning](https://developers.pipedrive.com/docs/api/v1/#/) says: 
> Warning!
> As of December 2, 2019, we will be removing the Authorizations endpoint:

> POST /authorizations
> We deprecated this endpoint on February 28, 2019, and we strongly advise you to avoid the use of this endpoint. The /authorizations endpoint is a legacy way of authorization using generic API keys. Such an approach does not provide transparency into which applications have access to data nor the opportunity to control the permissions these integrations have. Therefore we suggest using OAuth Authorization.

> In case you are using the /authorizations API endpoint in your code or 3rd party app/integration, please remove any dependency on this endpoint as soon as possible.

So this update adds the manual integration support and fix #11 

Also, I've updated pypi package with this release `pipedrive-python-lib==1.1.0` and updated the README. Refer to [Using this library with API Token](https://github.com/GearPlug/pipedrive-python/tree/master#using-this-library-with-api-token) for more information.

Thanks.
