### PR TITLE
fix delete_person bug

### DIFF
--- a/pipedrive/persons.py
+++ b/pipedrive/persons.py
@@ -24,7 +24,7 @@ class Persons(object):
 
     def delete_person(self, person_id, **kwargs):
         url = 'persons/{}'.format(person_id)
-        return self._client._delete(url, **kwargs)
+        return self._client._delete(self._client.BASE_URL + url, **kwargs)
 
     def get_person_deals(self, person_id, **kwargs):
         url = 'persons/{}/deals'.format(person_id)


### PR DESCRIPTION
The `delete_person()` method was missing the base URL. Unable to delete pipedrive persons due to that.