### PR TITLE
get_persons_activities() added to persons function list

### DIFF
--- a/pipedrive/persons.py
+++ b/pipedrive/persons.py
@@ -33,3 +33,7 @@ class Persons(object):
     def get_person_fields(self, params=None, **kwargs):
         url = "personFields"
         return self._client._get(self._client.BASE_URL + url, params=params, **kwargs)
+
+    def get_person_activities(self, person_id, **kwargs):
+        url = "persons/{}/activities".format(person_id)
+        return self._client._get(self._client.BASE_URL + url, **kwargs)


### PR DESCRIPTION
The get_persons_activities() was missing as one of the possible functions. We used the same code for the client.persons.get_persons_deals() function, but changed the final path and function name.